### PR TITLE
Editor 페이지에서 분리 해야 할 컴포넌트를 분리한다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,6 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/src/Page/Editor/components/Editor.tsx
+++ b/src/Page/Editor/components/Editor.tsx
@@ -16,12 +16,6 @@ const Editor = () => {
     key: number;
     element: JSX.Element;
   }
-  // const [isTemplates, setTemplates] = useState<React.ReactNode[]>([
-  //   <Template
-  //     deleteFunction={() => deleteTemplate({ setTemplate: setTemplates })}
-  //     key={isKey}
-  //   />,
-  // ]);
 
   const [isTemplates, setTemplates] = useState<TemplateInit[]>([
     {
@@ -30,8 +24,10 @@ const Editor = () => {
     },
   ]);
 
+  const newKey =
+    isTemplates.length === 0 ? 0 : isTemplates[isTemplates.length - 1].key + 1;
+
   const addTemplate = () => {
-    const newKey = isTemplates[isTemplates.length - 1].key + 1;
     setTemplates((prevTemplates) => [
       ...prevTemplates,
       {
@@ -49,6 +45,7 @@ const Editor = () => {
   };
 
   const deleteTemplate = (templateKey: number) => {
+    //templateKey = 삭제를 하기 위해 선택된 template
     setTemplates((prevTemplates) =>
       prevTemplates.filter((template) => template.key !== templateKey)
     );

--- a/src/Page/Editor/components/Editor.tsx
+++ b/src/Page/Editor/components/Editor.tsx
@@ -1,10 +1,6 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
-import mainLogo from "../../../image/logo-icon.svg";
-
-import saveIcon from "../image/save-icon.png";
-import editIcon from "../image/edit-icon.png";
-import deleteIcon from "../image/delete-icon.png";
+import { image } from "../../common/utils/img.data";
 
 import "../scss/editor.scss";
 import Button from "../../common/components/Button/Button";
@@ -12,6 +8,7 @@ import Template from "./Template";
 // import { addTemplate, deleteTemplate } from "../function/handleTemplate";
 
 const Editor = () => {
+  //useState의 interface 영역
   interface TemplateInit {
     key: number;
     element: JSX.Element;
@@ -24,6 +21,7 @@ const Editor = () => {
     },
   ]);
 
+  //?
   const newKey =
     isTemplates.length === 0 ? 0 : isTemplates[isTemplates.length - 1].key + 1;
 
@@ -54,7 +52,7 @@ const Editor = () => {
   return (
     <div className="editor">
       <div className="logo-image">
-        <img src={mainLogo} />
+        <img src={image.mainLogo} />
         <div className="group">
           <Button className="main-btn" link={<Link to="/">메인으로</Link>} />
           <div id="info-bg">

--- a/src/Page/Editor/components/Editor.tsx
+++ b/src/Page/Editor/components/Editor.tsx
@@ -1,61 +1,78 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import mainLogo from '../../../image/logo-icon.svg';
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import mainLogo from "../../../image/logo-icon.svg";
 
-import saveIcon from '../image/save-icon.png';
-import editIcon from '../image/edit-icon.png';
-import deleteIcon from '../image/delete-icon.png';
+import saveIcon from "../image/save-icon.png";
+import editIcon from "../image/edit-icon.png";
+import deleteIcon from "../image/delete-icon.png";
 
-import underLineIcon from '../image/underline-icon.png';
-import boldIcon from '../image/bold-icon.png';
-import italicIcon from '../image/italic-icon.png';
-import lineThroughIcon from '../image/line-through-icon.png';
-import '../scss/editor.scss'
-import Button from '../../common/components/Button/Button';
+import underLineIcon from "../image/underline-icon.png";
+import boldIcon from "../image/bold-icon.png";
+import italicIcon from "../image/italic-icon.png";
+import lineThroughIcon from "../image/line-through-icon.png";
+import "../scss/editor.scss";
+import Button from "../../common/components/Button/Button";
+import Template from "./Template";
+import { addTemplate, deleteTemplate } from "../function/handleTemplate";
 
 const Editor = () => {
+  const [isTemplates, setTemplates] = useState<React.ReactNode[]>([
+    <Template
+      deleteFunction={() => deleteTemplate({ setTemplate: setTemplates })}
+      key={0}
+    />,
+  ]);
+
   return (
-    <div className='editor'>
-      <div className='logo-image'>
+    <div className="editor">
+      <div className="logo-image">
         <img src={mainLogo} />
         <div className="group">
-          <Button className='main-btn' link={<Link to='/'>메인으로</Link>} />
+          <Button className="main-btn" link={<Link to="/">메인으로</Link>} />
           <div id="info-bg">
             <div id="info-icon">?</div>
           </div>
         </div>
       </div>
       <div className="edit">
-      <hr />
-      <h3>ToDoList</h3>
-        <div className='container'>
-
-          <div className="group">
-            <div className="btn">
-              <img src={saveIcon} id='btn'></img>
-              <img src={editIcon} id='btn'></img>
-              <img src={deleteIcon} id='btn'></img>
-            </div>
-            <div className='tool'>
-              <div className="elements">
-                <span id="tool">Tool</span>
-                <button className="btn">
-                  <img id="" src={underLineIcon} />
-                </button>
-              </div>
-            </div>
-            <div className="input">
-              <div className="elements">
-                <div
-                  contentEditable = 'true'
-                />
-              </div>
-            </div>
+        <hr />
+        <h3>ToDoList</h3>
+        {isTemplates.map((element, index) => (
+          <div className="template" key={index}>
+            {element}
           </div>
+        ))}
+        <div className="group">
+          <Button
+            id="btn-add"
+            onClick={() => {
+              addTemplate({
+                setTemplate: setTemplates,
+                Template: (
+                  <Template
+                    deleteFunction={() =>
+                      deleteTemplate({ setTemplate: setTemplates })
+                    }
+                    key={isTemplates.length}
+                  />
+                ),
+              });
+            }}
+            link="추가"
+          />
+          {/* <Button
+            id="btn-delete"
+            onClick={() => {
+              deleteTemplate({
+                setTemplate: setTemplates,
+              });
+            }}
+            link="삭제"
+          /> */}
         </div>
       </div>
     </div>
   );
-}
-  
+};
+
 export default Editor;

--- a/src/Page/Editor/components/Editor.tsx
+++ b/src/Page/Editor/components/Editor.tsx
@@ -6,22 +6,53 @@ import saveIcon from "../image/save-icon.png";
 import editIcon from "../image/edit-icon.png";
 import deleteIcon from "../image/delete-icon.png";
 
-import underLineIcon from "../image/underline-icon.png";
-import boldIcon from "../image/bold-icon.png";
-import italicIcon from "../image/italic-icon.png";
-import lineThroughIcon from "../image/line-through-icon.png";
 import "../scss/editor.scss";
 import Button from "../../common/components/Button/Button";
 import Template from "./Template";
-import { addTemplate, deleteTemplate } from "../function/handleTemplate";
+// import { addTemplate, deleteTemplate } from "../function/handleTemplate";
 
 const Editor = () => {
-  const [isTemplates, setTemplates] = useState<React.ReactNode[]>([
-    <Template
-      deleteFunction={() => deleteTemplate({ setTemplate: setTemplates })}
-      key={0}
-    />,
+  interface TemplateInit {
+    key: number;
+    element: JSX.Element;
+  }
+  // const [isTemplates, setTemplates] = useState<React.ReactNode[]>([
+  //   <Template
+  //     deleteFunction={() => deleteTemplate({ setTemplate: setTemplates })}
+  //     key={isKey}
+  //   />,
+  // ]);
+
+  const [isTemplates, setTemplates] = useState<TemplateInit[]>([
+    {
+      key: 0,
+      element: <Template key={0} deleteFunction={() => deleteTemplate(0)} />,
+    },
   ]);
+
+  const addTemplate = () => {
+    const newKey = isTemplates[isTemplates.length - 1].key + 1;
+    setTemplates((prevTemplates) => [
+      ...prevTemplates,
+      {
+        key: newKey,
+        element: (
+          <Template
+            key={newKey}
+            deleteFunction={() => deleteTemplate(newKey)}
+          />
+        ),
+      },
+    ]);
+    console.log(newKey);
+    console.log(isTemplates.length);
+  };
+
+  const deleteTemplate = (templateKey: number) => {
+    setTemplates((prevTemplates) =>
+      prevTemplates.filter((template) => template.key !== templateKey)
+    );
+  };
 
   return (
     <div className="editor">
@@ -37,29 +68,13 @@ const Editor = () => {
       <div className="edit">
         <hr />
         <h3>ToDoList</h3>
-        {isTemplates.map((element, index) => (
-          <div className="template" key={index}>
-            {element}
+        {isTemplates.map((template) => (
+          <div className="template" key={template.key}>
+            {template.element}
           </div>
         ))}
         <div className="group">
-          <Button
-            id="btn-add"
-            onClick={() => {
-              addTemplate({
-                setTemplate: setTemplates,
-                Template: (
-                  <Template
-                    deleteFunction={() =>
-                      deleteTemplate({ setTemplate: setTemplates })
-                    }
-                    key={isTemplates.length}
-                  />
-                ),
-              });
-            }}
-            link="추가"
-          />
+          <Button id="btn-add" onClick={addTemplate} link="추가" />
           {/* <Button
             id="btn-delete"
             onClick={() => {

--- a/src/Page/Editor/components/Template.tsx
+++ b/src/Page/Editor/components/Template.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from "react";
+
+import saveIcon from "../image/save-icon.png";
+import editIcon from "../image/edit-icon.png";
+import deleteIcon from "../image/delete-icon.png";
+
+import Button from "../../common/components/Button/Button";
+import Tool from "./Tool";
+
+interface TemplateProps {
+  deleteFunction: () => void;
+}
+
+const Template: React.FC<TemplateProps> = ({ deleteFunction }) => {
+  const [isName, setName] = useState("edit-mode");
+  const [isState, setState] = useState(true);
+
+  return (
+    <div className={isName}>
+      <div className="group">
+        <div className="btn">
+          <Button
+            id="btn"
+            onClick={() => {
+              console.log("save");
+              setName("save-mode");
+              setState(false);
+            }}
+            link={<img src={saveIcon} id="btn" />}
+          />
+
+          <Button
+            id="btn"
+            onClick={() => {
+              console.log("edit");
+              setName("edit-mode");
+              setState(true);
+            }}
+            link={<img src={editIcon} id="btn" />}
+          />
+
+          <Button
+            id="btn"
+            onClick={() => {
+              console.log("delete");
+              deleteFunction();
+            }}
+            link={<img src={deleteIcon} id="btn" />}
+          />
+        </div>
+        <div className="tool">{isState && <Tool />}</div>
+        <div className="input">
+          <div className="elements">
+            <div contentEditable={isState} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Template;

--- a/src/Page/Editor/components/Template.tsx
+++ b/src/Page/Editor/components/Template.tsx
@@ -1,8 +1,6 @@
 import React, { useState } from "react";
 
-import saveIcon from "../image/save-icon.png";
-import editIcon from "../image/edit-icon.png";
-import deleteIcon from "../image/delete-icon.png";
+import { image } from "../../common/utils/img.data";
 
 import Button from "../../common/components/Button/Button";
 import Tool from "./Tool";
@@ -27,7 +25,7 @@ const Template: React.FC<TemplateProps> = ({ deleteFunction }) => {
               setName("save-mode");
               setState(false);
             }}
-            link={<img src={saveIcon} id="btn" />}
+            link={<img src={image.saveIcon} id="btn" />}
           />
 
           <Button
@@ -37,7 +35,7 @@ const Template: React.FC<TemplateProps> = ({ deleteFunction }) => {
               setName("edit-mode");
               setState(true);
             }}
-            link={<img src={editIcon} id="btn" />}
+            link={<img src={image.editIcon} id="btn" />}
           />
 
           <Button
@@ -46,7 +44,7 @@ const Template: React.FC<TemplateProps> = ({ deleteFunction }) => {
               console.log("delete");
               deleteFunction();
             }}
-            link={<img src={deleteIcon} id="btn" />}
+            link={<img src={image.deleteIcon} id="btn" />}
           />
         </div>
         <div className="tool">{isState && <Tool />}</div>

--- a/src/Page/Editor/components/Template.tsx
+++ b/src/Page/Editor/components/Template.tsx
@@ -8,6 +8,7 @@ import Button from "../../common/components/Button/Button";
 import Tool from "./Tool";
 
 interface TemplateProps {
+  key?: any;
   deleteFunction: () => void;
 }
 

--- a/src/Page/Editor/components/Tool.tsx
+++ b/src/Page/Editor/components/Tool.tsx
@@ -1,0 +1,16 @@
+import underLineIcon from "../image/underline-icon.png";
+import boldIcon from "../image/bold-icon.png";
+import italicIcon from "../image/italic-icon.png";
+import lineThroughIcon from "../image/line-through-icon.png";
+
+const Tool = () => {
+  return (
+    <div className="elements">
+      <span id="tool">Tool</span>
+      <button className="btn">
+        <img id="" src={underLineIcon} />
+      </button>
+    </div>
+  );
+};
+export default Tool;

--- a/src/Page/Editor/components/Tool.tsx
+++ b/src/Page/Editor/components/Tool.tsx
@@ -1,14 +1,11 @@
-import underLineIcon from "../image/underline-icon.png";
-import boldIcon from "../image/bold-icon.png";
-import italicIcon from "../image/italic-icon.png";
-import lineThroughIcon from "../image/line-through-icon.png";
+import { image } from "../../common/utils/img.data";
 
 const Tool = () => {
   return (
     <div className="elements">
       <span id="tool">Tool</span>
       <button className="btn">
-        <img id="" src={underLineIcon} />
+        <img id="" src={image.underLineIcon} />
       </button>
     </div>
   );

--- a/src/Page/Editor/function/handleTemplate.ts
+++ b/src/Page/Editor/function/handleTemplate.ts
@@ -1,0 +1,19 @@
+interface TemplateSetProps {
+  setTemplate: React.Dispatch<React.SetStateAction<React.ReactNode[]>>;
+}
+interface TemplateProps extends TemplateSetProps {
+  Template: React.ReactNode;  // 컴포넌트 인스턴스를 직접 받도록 변경
+}
+
+export const addTemplate = ({ setTemplate, Template }: TemplateProps) => {
+  console.log("add");
+  setTemplate((prevTemplates) => [
+    ...prevTemplates,
+    Template
+  ]);
+};
+
+export const deleteTemplate = ({ setTemplate }: TemplateSetProps) => {
+  console.log("delete");
+  setTemplate((prevTemplates) => prevTemplates.slice(0, -1));
+};

--- a/src/Page/Editor/function/handleTemplate.ts
+++ b/src/Page/Editor/function/handleTemplate.ts
@@ -4,7 +4,7 @@ interface IAddTemplate {
   newKey: number;
   Template: React.ReactNode;
 }
-
+//addTemplate의 매개변수는 객체 형태이다. 그래서 타입 또한 객체 `{}`로 지정이 되어야한다.
 export const addTemplate = ({ setTemplate, newKey, Template }: IAddTemplate) => {
   setTemplate((prevTemplates) => [
     ...prevTemplates,

--- a/src/Page/Editor/function/handleTemplate.ts
+++ b/src/Page/Editor/function/handleTemplate.ts
@@ -1,21 +1,24 @@
-interface TemplateSetProps {
-  id?: any,
-  setTemplate: React.Dispatch<React.SetStateAction<React.ReactNode[]>>;
-}
-interface TemplateProps extends TemplateSetProps {
-  Template: React.ReactNode;  // 컴포넌트 인스턴스를 직접 받도록 변경
+interface IAddTemplate {
+  isTemplate: React.ReactNode[];
+  setTemplate: React.Dispatch<React.SetStateAction<{ key: number, element: React.ReactNode }[]>>;
+  newKey: number;
+  Template: React.ReactNode;
 }
 
-export const addTemplate = ({ id, setTemplate, Template }: TemplateProps) => {
-  console.log("add");
+export const addTemplate = ({ setTemplate, newKey, Template }: IAddTemplate) => {
   setTemplate((prevTemplates) => [
     ...prevTemplates,
-    Template
+    {
+      key: newKey,
+      element: Template
+    },
   ]);
+  console.log(newKey);
 };
 
-export const deleteTemplate = ({ id, setTemplate }: TemplateSetProps) => {
-  console.log("delete", id);
-  setTemplate((prevTemplates) => prevTemplates.slice(0, -1));
-  // setTemplate((prevTemplates) => prevTemplates.filter(template => template.id !== id));
+export const deleteTemplate = ({ setTemplate, newKey }: IAddTemplate) => {
+  //templateKey = 삭제를 하기 위해 선택된 template
+  setTemplate((prevTemplates) =>
+    prevTemplates.filter((template) => template.key !== newKey)
+  );
 };

--- a/src/Page/Editor/function/handleTemplate.ts
+++ b/src/Page/Editor/function/handleTemplate.ts
@@ -1,11 +1,12 @@
 interface TemplateSetProps {
+  id?: any,
   setTemplate: React.Dispatch<React.SetStateAction<React.ReactNode[]>>;
 }
 interface TemplateProps extends TemplateSetProps {
   Template: React.ReactNode;  // 컴포넌트 인스턴스를 직접 받도록 변경
 }
 
-export const addTemplate = ({ setTemplate, Template }: TemplateProps) => {
+export const addTemplate = ({ id, setTemplate, Template }: TemplateProps) => {
   console.log("add");
   setTemplate((prevTemplates) => [
     ...prevTemplates,
@@ -13,7 +14,8 @@ export const addTemplate = ({ setTemplate, Template }: TemplateProps) => {
   ]);
 };
 
-export const deleteTemplate = ({ setTemplate }: TemplateSetProps) => {
-  console.log("delete");
+export const deleteTemplate = ({ id, setTemplate }: TemplateSetProps) => {
+  console.log("delete", id);
   setTemplate((prevTemplates) => prevTemplates.slice(0, -1));
+  // setTemplate((prevTemplates) => prevTemplates.filter(template => template.id !== id));
 };

--- a/src/Page/Editor/scss/editor.scss
+++ b/src/Page/Editor/scss/editor.scss
@@ -30,6 +30,9 @@
       }
 
       #info-bg {
+        display: flex;
+        justify-content: center;
+        align-items: center;
         background-color: var(--editor-icon-bg);
         margin-top: 21px;
         border-radius: 50px;
@@ -50,81 +53,167 @@
   .edit {
     width: 100%;
 
-    hr {}
-
     h3 {
       font-weight: bold;
       font-size: 18px;
       margin: 30px 0px 23px 0px;
     }
 
+    .template {
+      .edit-mode {
+        background-color: var(--editor-main-bg);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        border-radius: 10px;
+        margin-bottom: 20px;
 
-    .container {
-      background-color: var(--editor-main-bg);
-      display: flex;
-      flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      border-radius: 10px;
+        .group {
+          // background-color: blueviolet;
+          margin: 0px 0px 23px 0px;
+          width: 1062px;
 
-      .group {
-        // background-color: blueviolet;
-        margin: 0px 0px 23px 0px;
-        width: 1062px;
-
-        >.btn {
-          // background-color: coral;
-          display: flex;
-          justify-content: flex-end;
-          margin: 22px 0px 22px 0px;
-          width: 100%;
-
-          #btn {
-            margin-left: 43px;
-          }
-        }
-
-        .tool {
-          background-color: var(--primary-bg);
-          display: flex;
-          justify-content: flex-start;
-          border-radius: 10px 10px 0px 0px;
-
-          .elements {
+          >.btn {
+            // background-color: coral;
             display: flex;
-            align-items: center;
-            width: 100%;
-            margin: 14.5px 21px 14.5px 21px;
+            // justify-content: flex-end;
+            margin: 22px 0px 22px 0px;
+            // width: 100%;
+            margin-left: 838px;
+            margin-right: 24px;
 
-            >.btn {
+            >#btn {
+              margin-left: 45px;
+            }
+          }
+
+          .tool {
+            background-color: var(--primary-bg);
+            display: flex;
+            justify-content: flex-start;
+            border-radius: 10px 10px 0px 0px;
+
+            .elements {
               display: flex;
               align-items: center;
-              background: none;
-              border: none;
-            }
+              width: 100%;
+              margin: 14.5px 21px 14.5px 21px;
 
-            #tool {
-              font-weight: bold;
-              color: var(--btn-main-bg);
-              margin-right: 25px;
+              >.btn {
+                display: flex;
+                align-items: center;
+                background: none;
+                border: none;
+              }
+
+              #tool {
+                font-weight: bold;
+                color: var(--btn-main-bg);
+                margin-right: 25px;
+              }
             }
           }
-        }
 
-        .input {
-          background-color: var(--primary-bg);
-          display: flex;
-          margin-top: 2px;
-          border-radius: 0px 0px 10px 10px;
+          .input {
+            background-color: var(--primary-bg);
+            display: flex;
+            margin-top: 2px;
+            border-radius: 0px 0px 10px 10px;
 
-          .elements {
-            // background-color: azure;
-            width: 100%;
-            margin: 14.5px 21px 14.5px 21px;
+            .elements {
+              // background-color: azure;
+              width: 100%;
+              margin: 14.5px 21px 14.5px 21px;
+            }
           }
         }
       }
+
+      .save-mode {
+        background-color: var(--editor-main-bg);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        border-radius: 10px;
+        margin-bottom: 20px;
+
+        .group {
+          margin: 0px 0px 23px 0px;
+
+          >.btn {
+            display: flex;
+            // justify-content: flex-end;
+            margin: 22px 0px 22px 0px;
+            // width: 1050px;
+            // width: 100%;
+            margin-left: 856px;
+            margin-right: 24px;
+
+            >#btn {
+              margin-left: 45px;
+            }
+          }
+
+          .tool {
+            .elements {
+              >.btn {}
+
+              #tool {}
+            }
+          }
+
+          .input {
+            background-color: var(--primary-bg);
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            margin-top: 2px;
+            height: 84px;
+            width: 1098px;
+
+            .elements {
+              width: 1062px;
+            }
+          }
+        }
+
+
+      }
     }
+
+    // >.group {
+    //   display: flex;
+
+    //   #btn-add {
+    //     display: flex;
+    //     justify-content: center;
+    //     align-items: center;
+    //     font-weight: bold;
+    //     width: 123px;
+    //     height: 39px;
+    //     border-radius: 10px;
+    //     background: var(--btn-main-bg);
+    //     color: var(--btn-main-font);
+    //     border: none;
+    //     margin-right: 20px;
+    //   }
+
+    //   #btn-delete {
+    //     display: flex;
+    //     justify-content: center;
+    //     align-items: center;
+    //     font-weight: bold;
+    //     width: 123px;
+    //     height: 39px;
+    //     border-radius: 10px;
+    //     background: var(--btn-main-bg);
+    //     color: var(--btn-main-font);
+    //     border: none;
+
+    //   }
+    // }
   }
 
 }

--- a/src/Page/Editor/test/TestHandleTemplate.ts
+++ b/src/Page/Editor/test/TestHandleTemplate.ts
@@ -1,0 +1,48 @@
+interface DeleteTemplateProps {
+  isTemplate: React.ReactNode[];
+  setTemplate: React.Dispatch<React.SetStateAction<React.ReactNode[]>>;
+}
+
+interface AddTemplateProps {
+  setTemplate: React.Dispatch<React.SetStateAction<React.ReactNode[]>>;
+  Template: React.ReactNode;  // 컴포넌트 인스턴스를 직접 받도록 변경
+}
+
+export const addTemplate = ({ setTemplate, Template }: AddTemplateProps) => {
+  console.log("add");
+  setTemplate((prevTemplates) => [
+    ...prevTemplates,
+    Template
+  ]);
+};
+
+export const deleteTemplate = ({ setTemplate, isTemplate }: DeleteTemplateProps) => {
+  console.log("delete");
+  setTemplate(isTemplate.slice(0, -1));
+};
+
+/**
+ * 위의 인터페이스는 아래와같은 방식으로 jsx로 사용된다.
+ * <div className="group">
+          <Button
+            id="btn-add"
+            onClick={() => {
+              addTemplate({
+                setTemplate: setTemplates,
+                Template: <Template key={isTemplates.length} />,
+              });
+            }}
+            link="추가"
+          />
+          <Button
+            id="btn-delete"
+            onClick={() => {
+              deleteTemplate({
+                setTemplate: setTemplates,
+                isTemplate: isTemplates,
+              });
+            }}
+            link="삭제"
+          />
+        </div>
+ */

--- a/src/Page/Editor/test/TestHandleTemplateNull.ts
+++ b/src/Page/Editor/test/TestHandleTemplateNull.ts
@@ -1,0 +1,43 @@
+interface TemplateProps {
+  setTemplate: React.Dispatch<React.SetStateAction<React.ReactNode[]>>;
+  Template: React.ReactNode;  // 컴포넌트 인스턴스를 직접 받도록 변경
+}
+
+export const addTemplate = ({ setTemplate, Template }: TemplateProps) => {
+  console.log("add");
+  setTemplate((prevTemplates) => [
+    ...prevTemplates,
+    Template
+  ]);
+};
+
+export const deleteTemplate = ({ setTemplate }: TemplateProps) => {
+  console.log("delete");
+  setTemplate((prevTemplates) => prevTemplates.slice(0, -1));
+};
+
+/**
+ * 위의 인터페이스는 아래와같은 방식으로 jsx로 사용된다.
+ * <div className="group">
+          <Button
+            id="btn-add"
+            onClick={() => {
+              addTemplate({
+                setTemplate: setTemplates,
+                Template: <Template key={isTemplates.length} />,
+              });
+            }}
+            link="추가"
+          />
+          <Button
+            id="btn-delete"
+            onClick={() => {
+              deleteTemplate({
+                setTemplate: setTemplates,
+                Template: null,
+              });
+            }}
+            link="삭제"
+          />
+        </div>
+ */

--- a/src/Page/Editor/test/oldHandleTemplate.ts
+++ b/src/Page/Editor/test/oldHandleTemplate.ts
@@ -1,0 +1,21 @@
+interface TemplateSetProps {
+  id?: any,
+  setTemplate: React.Dispatch<React.SetStateAction<React.ReactNode[]>>;
+}
+interface TemplateProps extends TemplateSetProps {
+  Template: React.ReactNode;  // 컴포넌트 인스턴스를 직접 받도록 변경
+}
+
+export const addTemplate = ({ id, setTemplate, Template }: TemplateProps) => {
+  console.log("add");
+  setTemplate((prevTemplates) => [
+    ...prevTemplates,
+    Template
+  ]);
+};
+
+export const deleteTemplate = ({ id, setTemplate }: TemplateSetProps) => {
+  console.log("delete", id);
+  setTemplate((prevTemplates) => prevTemplates.slice(0, -1));
+  // setTemplate((prevTemplates) => prevTemplates.filter(template => template.id !== id));
+};

--- a/src/Page/Main/components/Main.tsx
+++ b/src/Page/Main/components/Main.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import Button from "../../common/components/Button/Button";
-import mainLogo from "../../../image/logo-icon.svg";
 import "../scss/main.scss";
+import { image } from "../../common/utils/img.data";
 
 const Main = () => {
   return (
     <div className="main">
       <div className="logo-image">
-        <img src={mainLogo} />
+        <img src={image.mainLogo} />
       </div>
       <div className="group">
         <Button

--- a/src/Page/Main/components/Main.tsx
+++ b/src/Page/Main/components/Main.tsx
@@ -1,21 +1,38 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import Button from '../../common/components/Button/Button';
-import mainLogo from '../../../image/logo-icon.svg';
-import '../scss/main.scss';
+import React from "react";
+import { Link } from "react-router-dom";
+import Button from "../../common/components/Button/Button";
+import mainLogo from "../../../image/logo-icon.svg";
+import "../scss/main.scss";
 
 const Main = () => {
-  return(
-    <div className='main'>
-      <div className='logo-image'>
+  return (
+    <div className="main">
+      <div className="logo-image">
         <img src={mainLogo} />
       </div>
-      <div className='group'>
-        <Button className='btn' id='todo' link={<Link to='/editor'>ToDo</Link>} />
-        <Button className='btn' id='not-yet' link={<Link to='#' onClick={() => { alert('아직 준비 중입니다.😌') }}>준비 중</Link>} />
+      <div className="group">
+        <Button
+          className="btn"
+          id="todo"
+          link={<Link to="/editor">ToDo</Link>}
+        />
+        <Button
+          className="btn"
+          id="not-yet"
+          link={
+            <Link
+              to="#"
+              onClick={() => {
+                alert("아직 준비 중입니다.😌");
+              }}
+            >
+              준비 중
+            </Link>
+          }
+        />
       </div>
     </div>
   );
-}
+};
 
 export default Main;

--- a/src/Page/common/components/Button/Button.tsx
+++ b/src/Page/common/components/Button/Button.tsx
@@ -1,17 +1,18 @@
-import React from "react"
+import React from "react";
 
-interface ButtonProps{
+interface ButtonProps {
   className?: string;
   id?: string;
-  link: React.ReactNode;
+  link?: React.ReactNode | string;
+  onClick?: () => void;
 }
 
-const Button : React.FC<ButtonProps> = ({ className, id, link}) => { 
+const Button: React.FC<ButtonProps> = ({ className, id, link, onClick }) => {
   return (
-    <div className={ className} id={ id }>
+    <div className={className} id={id} onClick={onClick}>
       {link}
     </div>
   );
-}
+};
 
 export default Button;

--- a/src/Page/common/function/ButtonAdd.tsx
+++ b/src/Page/common/function/ButtonAdd.tsx
@@ -1,0 +1,4 @@
+const ButtonAdd = () => {
+  return <></>;
+};
+export default ButtonAdd;

--- a/src/Page/common/function/ButtonDelete.tsx
+++ b/src/Page/common/function/ButtonDelete.tsx
@@ -1,0 +1,4 @@
+const ButtonDelete = () => {
+  return <></>;
+};
+export default ButtonDelete;

--- a/src/Page/common/utils/img.data.ts
+++ b/src/Page/common/utils/img.data.ts
@@ -1,0 +1,13 @@
+export const image = {
+  // Main
+  mainLogo: require("../../../image/logo-icon.svg").default,
+  // Editor
+  saveIcon: require("../../Editor/image/save-icon.png").default,
+  editIcon: require("../../Editor/image/edit-icon.png").default,
+  deleteIcon: require("../../Editor/image/delete-icon.png").default,
+  // Editor>Tool
+  underLineIcon: require("../../Editor/image/underline-icon.png").default,
+  boldIcon: require("../../Editor/image/bold-icon.png").default,
+  italicIcon: require("../../Editor/image/italic-icon.png").default,
+  lineThroughIcon: require("../../Editor/image/line-through-icon.png").default,
+}

--- a/src/Page/common/utils/interface.ts
+++ b/src/Page/common/utils/interface.ts
@@ -1,0 +1,3 @@
+export const test = () => {
+  return 'test';
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
### #️⃣ Issue Number
- close #5 

### ✏️Task
- [x] interface를 적용해서 컴포넌트를 생성, 추가하는 함수를 구현한다.
- [x] editor 컴포넌트가 편집모드, 완성모드 이렇게 두가지로 나뉠 수 있게 CSS를 구현하다.
- [x]  img를 관리하는 데이터 객체를 생성

### ✏️Tasks Description

* editor 컴포넌트가 편집모드, 완성모드 이렇게 두가지로 나뉠 수 있게 CSS를 구현하다.
  * 두 가지 모드로 전환이 될 수 있게 className으로 컨트롤 하게 했다. `Teamplte.tsx`에서 `useState`훅을 통해 `isName, setName`을 가지고 저장 버튼을 눌렀을 때 'save-mode' 수정 버튼을 눌렀을 때 'edit-mode' 이렇게 로직을 짰다. 처음에는 css파일을 두가지로 나누어서 삼항 연자를 사용해서 컨트롤 할 수 있게 하려고 했지만 해당 기능은 mode를 전환해야하는 부분이라서 추후에 여러 모드가 추가 될 수도 있기 때문에 삼항 연산자로 mode를 관리하기에는 경우의 수가 많아 `useState`로 관리할 수 있도록 했다. 
*  interface를 적용해서 컴포넌트를 생성, 추가하는 함수를 구현한다.
  * Template를 생성할 수 있는 코드를 `Editor.tsx`파일에서 컨트롤 할 수 있도록 코드를 수정 했다. 생성, 삭제하는 부분을 `addTemplate`, `deleteTemplate`라는 함수로 분리했다. `addTemplate` 함수에서 Tempalte를 생성할 때 `useState`로 관리하는데 `isTempaltes`, `setTemplates`로 추가, 삭제 할 수 있게 관리한다. 해당 `useState`는 배열 객체로 생성 할 수 있게 초기값을 주었다. 초기값은 `key`, `element` 이렇게 두가지이다. key는 배열 요소의 고유 key값을 주기 위함이며 element는 Tempalte라는 컴포넌트를 생성 할 수 있는 객체이다. 초기에는 삭제 함수를 Editor 컴포넌트 페이지에서 관리할 수 있도록 했지만 UI/UX적인 측면에서보면 해당 Template마다 삭제 버튼이 있고 선택한 Template가 삭제되는 것이 UX적으로 좋다고 판단이 되어 삭제 함수는 Template의 Props로 전달 받게 구성 했다.
  * newKey
    * newKey는 생성된 Tempalte의 마지막 Template의 위치에 key값을 `+1`씩 증가할 수 있게 삼항연산자로 로직을 작성했다. 즉, 현재 Template의 상태변수에서 배열 마지막 key값 보다 `+1`이 되어 있는 값을 보관 하고 있는 것이다. 따라서, Template의 상태변수(isTemplates)에 따라 동적으로 다음 key 값이 미리 준비 되는 것이다.
  * [🚩: interface를 다루는 ts파일 생성](https://github.com/4BFC/EditorTool/commit/c8e784c2ba32093bc9cc0b6ac2cb16b275c7abae)
* img를 관리하는 데이터 객체를 생성
  * utils라는 디렉토리를 생성해서 `img.data.ts`파일에 Node 문법을 사용해서 이미지 들을 객체로 관리할 수 있게 구성했다.
  * [🚩: img를 관리하는 데이터 함수 생성](https://github.com/4BFC/EditorTool/commit/9ffc81ba7b634e53bcd065d585bc50913c859552)


### 🗓Next Task
- 
